### PR TITLE
Fixed Variable Cost Script to recreate data instead of appending data

### DIFF
--- a/src/osemosys_global/OPG_variablecosts.py
+++ b/src/osemosys_global/OPG_variablecosts.py
@@ -178,4 +178,4 @@ df_varcosts_final = df_varcost[['REGION',
                        'YEAR', 
                        'VALUE']]
 
-df_varcosts_final.to_csv(os.path.join(output_dir,'VariableCost.csv'), mode='a', header=True, index = None)
+df_varcosts_final.to_csv(os.path.join(output_dir,'VariableCost.csv'), header=True, index = None)


### PR DESCRIPTION
Removed the append mode argument when writing to a csv. The script now overwrites any existing data currently in the VariableCost.csv file. Addresses issue #50 