### PR TITLE
Result summaries and bug fixes for hourly results visualisation

### DIFF
--- a/resources/osemosys_fast_preprocessed.txt
+++ b/resources/osemosys_fast_preprocessed.txt
@@ -198,8 +198,8 @@ check{r in REGION, t in TECHNOLOGY, y in YEAR:TotalAnnualMaxCapacity[r,t,y]<>0 &
 #####    'Time Slice' check     #####
 printf "Checking TimeSlices/YearSplits for y in YEAR \n";
 #
-check{y in YEAR}: sum{l in TIMESLICE} YearSplit[l,y] >= 0.9999;
-check{y in YEAR}: sum{l in TIMESLICE} YearSplit[l,y] <= 1.0001;
+check{y in YEAR}: sum{l in TIMESLICE} YearSplit[l,y] >= 0.98;
+check{y in YEAR}: sum{l in TIMESLICE} YearSplit[l,y] <= 1.02;
 #
 #####   'Model period activity limit' check   #####
 printf "Checking Model period activity bounds for r in REGION, t in TECHNOLOGY \n";
@@ -306,7 +306,7 @@ var OperatingCost{r in REGION, t in TECHNOLOGY, y in YEAR}>= 0;
 #var AnnualVariableOperatingCost{r in REGION, t in TECHNOLOGY, y in YEAR}>= 0;
 #var AnnualFixedOperatingCost{r in REGION, t in TECHNOLOGY, y in YEAR}>= 0;
 #var TotalDiscountedCostByTechnology{r in REGION, t in TECHNOLOGY, y in YEAR}>= 0;
-#var TotalDiscountedCost{r in REGION, y in YEAR}>= 0;
+var TotalDiscountedCost{r in REGION, y in YEAR}>= 0;
 #var ModelPeriodCostByRegion{r in REGION} >= 0;
 #
 #########                        Reserve Margin                                #############
@@ -488,7 +488,7 @@ s.t. SV4_SalvageValueDiscountedToStartYear{r in REGION, t in TECHNOLOGY, y in YE
 #########               Total Discounted Costs                 #############
 #
 #s.t. TDC1_TotalDiscountedCostByTechnology{r in REGION, t in TECHNOLOGY, y in YEAR}: ((((sum{yy in YEAR: y-yy < OperationalLife[r,t] && y-yy>=0} NewCapacity[r,t,yy])+ ResidualCapacity[r,t,y])*FixedCost[r,t,y] + sum{m in MODEperTECHNOLOGY[t], l in TIMESLICE} RateOfActivity[r,l,t,m,y]*YearSplit[l,y]*VariableCost[r,t,m,y])/DiscountFactorMid[r,y]+CapitalCost[r,t,y] * NewCapacity[r,t,y]/DiscountFactor[r,y]+DiscountedTechnologyEmissionsPenalty[r,t,y]-DiscountedSalvageValue[r,t,y]) = TotalDiscountedCostByTechnology[r,t,y];
-####s.t. TDC2_TotalDiscountedCost{r in REGION, y in YEAR}: sum{t in TECHNOLOGY}((((sum{yy in YEAR: y-yy < OperationalLife[r,t] && y-yy>=0} NewCapacity[r,t,yy])+ ResidualCapacity[r,t,y])*FixedCost[r,t,y] + sum{m in MODEperTECHNOLOGY[t], l in TIMESLICE} RateOfActivity[r,l,t,m,y]*YearSplit[l,y]*VariableCost[r,t,m,y])/DiscountFactorMid[r,y]+CapitalCost[r,t,y] * NewCapacity[r,t,y]/DiscountFactor[r,y]+DiscountedTechnologyEmissionsPenalty[r,t,y]-DiscountedSalvageValue[r,t,y]) + sum{s in STORAGE} (CapitalCostStorage[r,s,y] * NewStorageCapacity[r,s,y]/DiscountFactor[r,y]-CapitalCostStorage[r,s,y] * NewStorageCapacity[r,s,y]/DiscountFactor[r,y]) = TotalDiscountedCost[r,y];
+s.t. TDC2_TotalDiscountedCost{r in REGION, y in YEAR}: sum{t in TECHNOLOGY}((((sum{yy in YEAR: y-yy < OperationalLife[r,t] && y-yy>=0} NewCapacity[r,t,yy])+ ResidualCapacity[r,t,y])*FixedCost[r,t,y] + sum{m in MODEperTECHNOLOGY[t], l in TIMESLICE} RateOfActivity[r,l,t,m,y]*YearSplit[l,y]*VariableCost[r,t,m,y])/DiscountFactorMid[r,y]+CapitalCost[r,t,y] * NewCapacity[r,t,y]/DiscountFactor[r,y]+DiscountedTechnologyEmissionsPenalty[r,t,y]-DiscountedSalvageValue[r,t,y]) + sum{s in STORAGE} (CapitalCostStorage[r,s,y] * NewStorageCapacity[r,s,y]/DiscountFactor[r,y]-CapitalCostStorage[r,s,y] * NewStorageCapacity[r,s,y]/DiscountFactor[r,y]) = TotalDiscountedCost[r,y];
 #
 #########                      Total Capacity Constraints         ##############
 #

--- a/workflow/rules/postprocess.smk
+++ b/workflow/rules/postprocess.smk
@@ -38,6 +38,10 @@ result_figures = [
     'GenerationAnnual',
 ]
 
+result_summaries = [
+    'Metrics'
+]
+
 # RULES
 
 rule otoole_results:
@@ -72,3 +76,18 @@ rule visualisation:
         'workflow/logs/visualisation.log'
     shell: 
         'python workflow/scripts/osemosys_global/visualisation.py 2> {log}'
+
+rule summarise_results:
+    message:
+        'Generating summary of results...'
+    input:
+        expand(Path(output_dir, scenario, 'results/{result_file}'), result_file = result_files),
+        'config/config.yaml',
+    output:
+        expand(Path(output_dir, scenario, 'result_summaries/{result_summary}.csv'), result_summary = result_summaries),
+    conda:
+        '../envs/data_processing.yaml'
+    log:
+        'workflow/logs/summarise_results.log'
+    shell: 
+        'python workflow/scripts/osemosys_global/summarise_results.py 2> {log}'

--- a/workflow/scripts/osemosys_global/OPG_configuration.py
+++ b/workflow/scripts/osemosys_global/OPG_configuration.py
@@ -44,6 +44,8 @@ class ConfigPaths:
         self.scenario_data_dir = Path(self.scenario_dir, 'data')
         self.scenario_figs_dir = Path(self.scenario_dir, 'figures')
         self.scenario_results_dir = Path(self.scenario_dir, 'results')
+        self.scenario_result_summaries_dir = Path(self.scenario_dir,
+                                                  'result_summaries')
 
         self.simplicity = Path(self.input_dir, 'simplicity')
         self.simplicity_data = Path(self.input_dir, 'simplicity/data')

--- a/workflow/scripts/osemosys_global/summarise_results.py
+++ b/workflow/scripts/osemosys_global/summarise_results.py
@@ -1,0 +1,89 @@
+import pandas as pd
+import itertools
+import os
+import sys
+import yaml
+from OPG_configuration import ConfigFile, ConfigPaths
+pd.set_option('mode.chained_assignment', None)
+
+
+def main():
+    '''Creates system level and country level graphs. '''
+
+    config_paths = ConfigPaths()
+    config = ConfigFile('config')
+    scenario_results_dir = '/home/abhi/osemosys_global/results/osemosys-global/results'
+    
+    print(os.getcwd())
+
+    # SUMMARISE RESULTS
+    headline_metrics()
+
+
+def renewables_filter(df):
+    '''Function to filter and keep only renewable
+    technologies'''
+    renewables = ['BIO', 'CSP', 'GEO', 'HYD', 'SPV', 'WON', 'WOF']
+    df = df.loc[(df.TECHNOLOGY.str.startswith('PWR')) &
+                (df.TECHNOLOGY.str[3:6].isin(renewables))
+                ]
+    return df
+
+
+def fossil_filter(df):
+    '''Function to filter and keep only fossil fuel
+    technologies'''
+    fossil_fuels = ['BIO', 'CSP', 'HYD', 'SPV', 'WON', 'WOF']
+    df = df.loc[(df.TECHNOLOGY.str.startswith('PWR')) &
+                (df.TECHNOLOGY.str[3:6].isin(fossil_fuels))
+                ]
+    return df
+
+
+def headline_metrics():
+    '''Function to summarise metrics for:
+       1. Total emissions
+       2. Average RE share
+       3. Average cost of electricity generation
+       4. Total system cost
+       5. Average fossil fuel share'''
+
+    # CONFIGURATION PARAMETERS
+    config_paths = ConfigPaths()
+    scenario_results_dir = '/home/abhi/osemosys_global/results/osemosys-global/results'
+    
+    # GET RESULTS
+
+    metrics = {}
+    # Total Emissions
+    df_emissions = pd.read_csv(os.path.join(scenario_results_dir,
+                                            'AnnualEmissions.csv'
+                                            )
+                               )
+    emissions_total = df_emissions.VALUE.sum()
+    metrics['Emissions'] = emissions_total.round(0)
+
+    # RE Share
+    df_re_share = pd.read_csv(os.path.join(scenario_results_dir,
+                                           'ProductionByTechnologyAnnual.csv'
+                                           )
+                              )
+    gen_total = df_re_share.loc[df_re_share.TECHNOLOGY.str.startswith('PWR'),
+                                'VALUE'].sum()
+    df_re_share = renewables_filter(df_re_share)
+    re_total = df_re_share.VALUE.sum()
+    re_share = re_total / gen_total
+    metrics['RE Share'] = (re_share*100).round(0)
+
+    # Total System Cost
+    df_system_cost = pd.read_csv(os.path.join(scenario_results_dir,
+                                              'TotalDiscountedCost.csv'
+                                              )
+                                 )
+    system_cost_total = df_system_cost.VALUE.sum()
+
+    return print(metrics)
+
+
+if __name__ == '__main__':
+    main()

--- a/workflow/scripts/osemosys_global/summarise_results.py
+++ b/workflow/scripts/osemosys_global/summarise_results.py
@@ -118,6 +118,21 @@ def headline_metrics():
     df_metrics.loc[df_metrics['Metric'].str.startswith('Total System Cost'),
                    'Value'] = (system_cost_total/1000).round(0)
 
+    # Cost of electricity generation
+    df_demand = pd.read_csv(os.path.join(scenario_results_dir,
+                                         'Demand.csv'
+                                         )
+                            )
+    demand_total = df_demand.VALUE.sum()  # Total demand in TWh
+    df_metrics.loc[df_metrics['Metric'].str.startswith('Cost of electricity'),
+                   'Value'] = (system_cost_total/(demand_total*0.2778)).round(0)
+
+    return df_metrics.to_csv(os.path.join(scenario_result_summaries_dir,
+                                          'Metrics.csv'
+                                          ),
+                             index=None
+                             )
+
     return df_metrics.to_csv(os.path.join(scenario_result_summaries_dir,
                                           'Metrics.csv'
                                           ),

--- a/workflow/snakefile
+++ b/workflow/snakefile
@@ -35,7 +35,7 @@ rule all:
     message:
         'All rules executed successfully...'
     input:
-        rules.visualisation.output
+        rules.summarise_results.output
 
 rule data_file:
     message: 

--- a/workflow/snakefile
+++ b/workflow/snakefile
@@ -35,7 +35,8 @@ rule all:
     message:
         'All rules executed successfully...'
     input:
-        rules.summarise_results.output
+        rules.summarise_results.output,
+        rules.visualisation.output
 
 rule data_file:
     message: 


### PR DESCRIPTION
Result summaries and bug fixes in hourly results visualisation

### Description
- Rule to create four result summaries: Headline metrics, annual capacities by node, hourly generation by node, and hourly cross-border trade flows by node pair.
- Headline metrics include: total emissions, total system cost, average cost of electricity generation, RE share of total generation, and fossil fuel share of total generation


### Issue Ticket Number
No corresponding Issue


### Documentation
![OSeMOSYS Global platform](https://user-images.githubusercontent.com/12281603/161931232-2826e050-6548-4edb-a803-57720357edbd.svg)

