### PR TITLE
Added timeshift parameter

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -21,7 +21,7 @@ seasons:
   S2: [3, 4, 5]
   S3: [6, 7, 8]
   S4: [9, 10, 11]
-timeshift: 6 # value between -11 and 12
+timeshift: 0 # value between -11 and 12
   
 # Spatial Parameters 
 geographic_scope:

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -21,6 +21,7 @@ seasons:
   S2: [3, 4, 5]
   S3: [6, 7, 8]
   S4: [9, 10, 11]
+timeshift: 6 # value between -11 and 12
   
 # Spatial Parameters 
 geographic_scope:

--- a/workflow/scripts/osemosys_global/visualisation.py
+++ b/workflow/scripts/osemosys_global/visualisation.py
@@ -129,6 +129,9 @@ def transform_ts(df):
         daypartData.append([dp, hr[0], hr[1]])
     dayparts_df = pd.DataFrame(daypartData,
                                columns=['daypart', 'start_hour', 'end_hour'])
+    timeshift = config.get('timeshift')
+    dayparts_df['start_hour'] = dayparts_df['start_hour'].map(lambda x: apply_timeshift(x, timeshift))
+    dayparts_df['end_hour'] = dayparts_df['end_hour'].map(lambda x: apply_timeshift(x, timeshift))
 
     month_names = {1: 'Jan',
                    2: 'Feb',
@@ -207,10 +210,15 @@ def transform_ts(df):
     df_ts_template['YEAR'] = df_ts_template['YEAR'].astype(int)
     df_ts_template = powerplant_filter(df_ts_template)
 
-    for each in dayparts_dict:
-        df_ts_template.loc[(df_ts_template.HOUR > dayparts_dict[each][0]) &
-                           (df_ts_template.HOUR <= dayparts_dict[each][1]),
-                           'DAYPART'] = each
+    for daypart in dayparts_dict:
+        if dayparts_dict[daypart][0] > dayparts_dict[daypart][1]: # loops over 24hrs
+            df_ts_template.loc[(df_ts_template['HOUR'] >= dayparts_dict[daypart][0]) |
+                          (df_ts_template['HOUR'] < dayparts_dict[daypart][1]),
+                          'DAYPART'] = daypart
+        else:
+            df_ts_template.loc[(df_ts_template['HOUR'] >= dayparts_dict[daypart][0]) &
+                      (df_ts_template['HOUR'] < dayparts_dict[daypart][1]),
+                      'DAYPART'] = daypart
 
     df['SEASON'] = df['TIMESLICE'].str[0:2]
     df['DAYPART'] = df['TIMESLICE'].str[2:]
@@ -402,6 +410,21 @@ def plot_generation_hourly():
                                        'GenerationHourly.html'
                                        )
                           )
+
+def apply_timeshift(x, timeshift):
+    '''Applies timeshift to organize dayparts.
+    
+    Args:
+        x = Value between 0-24
+        timeshift = value offset from UTC (-11 -> +12)'''
+
+    x += timeshift
+    if x > 23:
+        return x - 24
+    elif x < 0:
+        return x + 24
+    else:
+        return x
 
 if __name__ == '__main__':
     main()


### PR DESCRIPTION
<!--- Provide a short description of the changes in the Title -->

### Description
<!--- Describe your changes in detail -->
Added a new parameter to the configuration file to manage time offsets. 

For example, India has a +6 time offset when compared to the UTC. This means if we set the dayparts to be DP1: 12am->12pm and DP2: 12pm->12am, it will actually be DP1: 6am->6pm and DP2: 6pm->6am. 

To allow users to easily correct this, a `timeshift` parameter has been added to change where the reference time 0 is. If the user selects DP1: 12am->12pm and DP2: 12pm->12am and includes the parameter `timeshift: -6`, then then dayparts will offset to truly be DP1: 12am->12pm and DP2: 12pm->12am for India. 

### Issue Ticket Number
<!--- Link corresponding issue number -->
closes #128 

### Documentation
<!--- Where and how has this change been documented -->
To be documented...