### PR TITLE
User-defined capacities

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -17,14 +17,17 @@ dayparts:
   D2: [12, 24]
 seasons:
   #season : [month 1, month 2, ...] (all inclusive)
-  S1: [12, 1, 2]
-  S2: [3, 4, 5]
-  S3: [6, 7, 8]
-  S4: [9, 10, 11]
+  S1: [1, 2, 3, 4, 5, 6]
+  S2: [6, 7, 8, 9, 10, 11, 12]
+  # S3: [6, 7, 8]
+  # S4: [9, 10, 11]
   
 # Spatial Parameters 
 geographic_scope:
   - 'IND'
+  - 'NPL'
+  - 'BGD'
+  - 'BTN'
 crossborderTrade: True
 
 # Emission Parameters 
@@ -39,3 +42,9 @@ no_invest_technologies:
 
 # Result Parameters 
 results_by_country: True
+
+user_defined_capacity:
+  #technology: [capacity, first_year,]
+  TRNINDEANPLXX: [10, 2017]
+  TRNINDEAINDSO: [5, 2048]
+  TRNINDNOINDWE: [2, 2035]

--- a/workflow/rules/model.smk
+++ b/workflow/rules/model.smk
@@ -29,6 +29,24 @@ rule geographic_filter:
     shell:
         'python workflow/scripts/osemosys_global/OPG_geographic_filter.py 2> {log}'
 
+rule user_capacity:
+    message: 
+        'Generating user-defined capacities...'
+    input:
+        Path(output_dir, scenario, 'data/TECHNOLOGY.csv'),
+        Path(output_dir, scenario, 'data/TotalAnnualMinCapacityInvestment.csv'),
+        Path(output_dir, scenario, 'data/TotalAnnualMaxCapacityInvestment.csv'),
+        'config/config.yaml'
+    output:
+        expand(Path(output_dir, scenario, 'data/{output_file}'), output_file = user_capacity_files),
+        touch('workflow/rules/flags/user_capacity.done')
+    conda:
+        '../envs/data_processing.yaml'
+    log:
+        'workflow/logs/user_defined_capacity.log'
+    shell:
+        'python workflow/scripts/osemosys_global/user_defined_capacity.py 2> {log}'
+
 rule otoole_convert:
     message:
         'Creating data file...'

--- a/workflow/rules/model.smk
+++ b/workflow/rules/model.smk
@@ -29,24 +29,6 @@ rule geographic_filter:
     shell:
         'python workflow/scripts/osemosys_global/OPG_geographic_filter.py 2> {log}'
 
-rule user_capacity:
-    message: 
-        'Generating user-defined capacities...'
-    input:
-        Path(output_dir, scenario, 'data/TECHNOLOGY.csv'),
-        Path(output_dir, scenario, 'data/TotalAnnualMinCapacityInvestment.csv'),
-        Path(output_dir, scenario, 'data/TotalAnnualMaxCapacityInvestment.csv'),
-        'config/config.yaml'
-    output:
-        expand(Path(output_dir, scenario, 'data/{output_file}'), output_file = user_capacity_files),
-        touch('workflow/rules/flags/user_capacity.done')
-    conda:
-        '../envs/data_processing.yaml'
-    log:
-        'workflow/logs/user_defined_capacity.log'
-    shell:
-        'python workflow/scripts/osemosys_global/user_defined_capacity.py 2> {log}'
-
 rule otoole_convert:
     message:
         'Creating data file...'

--- a/workflow/rules/preprocess.smk
+++ b/workflow/rules/preprocess.smk
@@ -73,6 +73,11 @@ max_capacity_files = [
     'TotalAnnualMaxCapacity.csv'
 ]
 
+user_capacity_files = [
+    'TotalAnnualMinCapacityInvestment.csv',
+    'TotalAnnualMaxCapacityInvestment.csv'
+]
+
 # DATA PROCESSING RULES 
 
 rule powerplant:

--- a/workflow/rules/preprocess.smk
+++ b/workflow/rules/preprocess.smk
@@ -37,6 +37,7 @@ power_plant_files = [
     'CapacityToActivityUnit.csv',
     'OperationalLife.csv',
     'TotalAnnualMaxCapacityInvestment.csv',
+    'TotalAnnualMinCapacityInvestment.csv',
     'TotalTechnologyModelPeriodActivityUpperLimit.csv',
     'FUEL.csv',
     'InputActivityRatio.csv',

--- a/workflow/scripts/osemosys_global/OPG_powerplant_data.py
+++ b/workflow/scripts/osemosys_global/OPG_powerplant_data.py
@@ -1455,14 +1455,12 @@ def user_defined_capacity(region, years, output_data_dir, tech_capacity):
     tech_capacity_df['REGION'] = region
     tech_capacity_df = tech_capacity_df[['REGION', 'TECHNOLOGY', 'YEAR', 'VALUE']]
 
-    '''
-    tech_set = pd.read_csv(os.path.join(scenario_data_dir, 'TECHNOLOGY.csv'))
+    tech_set = pd.read_csv(os.path.join(output_data_dir, 'TECHNOLOGY.csv'))
 
     for each_tech in list(tech_capacity_df['TECHNOLOGY'].unique()):
         if each_tech not in list(tech_set['VALUE']):
             tech_capacity_df = tech_capacity_df.loc[~(tech_capacity_df['TECHNOLOGY'].isin([each_tech]))]
-    '''
-
+    
     df_min_cap_inv = pd.read_csv(os.path.join(output_data_dir,
                                               'TotalAnnualMinCapacityInvestment.csv'))
     df_min_cap_inv = df_min_cap_inv.append(tech_capacity_df)

--- a/workflow/scripts/osemosys_global/OPG_powerplant_data.py
+++ b/workflow/scripts/osemosys_global/OPG_powerplant_data.py
@@ -36,6 +36,8 @@ def main():
     years = list(range(model_start_year, model_end_year + 1))
 
     region_name = config.get('region')
+    
+    tech_capacity = config.get('user_defined_capacity')
 
     # Create output directory 
     if not os.path.exists(output_data_dir):
@@ -1195,7 +1197,13 @@ def main():
                                     )       
     df_max_cap_invest.to_csv(os.path.join(output_data_dir, 
                                             'TotalAnnualMaxCapacityInvestment.csv'),
-                                        index = None)                                              
+                                        index = None)
+    
+    df_min_cap_invest = pd.DataFrame(columns = ['REGION', 'TECHNOLOGY', 'YEAR', 'VALUE']
+                                    )
+    df_min_cap_invest.to_csv(os.path.join(output_data_dir, 
+                                            'TotalAnnualMinCapacityInvestment.csv'),
+                                        index = None)
 
     # ## Create sets for TECHNOLOGIES, FUELS
     create_sets('TECHNOLOGY', df_oar_final, output_data_dir)
@@ -1218,6 +1226,8 @@ def main():
     regions_df.to_csv(os.path.join(output_data_dir, 
                                    "REGION.csv"),
                       index = None)
+    
+    user_defined_capacity(region_name, years, output_data_dir, tech_capacity)
 
 
 def create_sets(x, df, output_dir):
@@ -1434,6 +1444,59 @@ def format_transmission_name(df):
     df = df.drop(["From", "To"], axis=1)
 
     return df
+
+def user_defined_capacity(region, years, output_data_dir, tech_capacity):
+    techCapacity = []
+
+    for tech, tech_params in tech_capacity.items():
+        techCapacity.append([tech, tech_params[0], tech_params[1]])
+    tech_capacity_df = pd.DataFrame(techCapacity,
+                                    columns=['TECHNOLOGY', 'VALUE', 'YEAR'])
+    tech_capacity_df['REGION'] = region
+    tech_capacity_df = tech_capacity_df[['REGION', 'TECHNOLOGY', 'YEAR', 'VALUE']]
+
+    '''
+    tech_set = pd.read_csv(os.path.join(scenario_data_dir, 'TECHNOLOGY.csv'))
+
+    for each_tech in list(tech_capacity_df['TECHNOLOGY'].unique()):
+        if each_tech not in list(tech_set['VALUE']):
+            tech_capacity_df = tech_capacity_df.loc[~(tech_capacity_df['TECHNOLOGY'].isin([each_tech]))]
+    '''
+
+    df_min_cap_inv = pd.read_csv(os.path.join(output_data_dir,
+                                              'TotalAnnualMinCapacityInvestment.csv'))
+    df_min_cap_inv = df_min_cap_inv.append(tech_capacity_df)
+    df_min_cap_inv.drop_duplicates(inplace=True)
+
+    df_max_cap_inv = pd.read_csv(os.path.join(output_data_dir,
+                                              'TotalAnnualMaxCapacityInvestment.csv'))
+
+    max_cap_techs = []
+    for index, row in tech_capacity_df.iterrows():
+        for each_year in years:
+            if row['YEAR'] == each_year:
+                value = row['VALUE']
+            else:
+                value = 0
+            max_cap_techs.append([row['REGION'],
+                                row['TECHNOLOGY'],
+                                each_year,
+                                value])
+    max_cap_techs_df = pd.DataFrame(max_cap_techs,
+                                    columns=['REGION',
+                                            'TECHNOLOGY',
+                                            'YEAR',
+                                            'VALUE'])
+    df_max_cap_inv = df_max_cap_inv.append(max_cap_techs_df)
+    df_max_cap_inv.drop_duplicates(inplace=True)
+
+    df_max_cap_inv.to_csv(os.path.join(output_data_dir,
+                                    "TotalAnnualMaxCapacityInvestment.csv"),
+                        index=None)
+    df_min_cap_inv.to_csv(os.path.join(output_data_dir,
+                                    "TotalAnnualMinCapacityInvestment.csv"),
+                        index=None)
+            
 
 if __name__ == "__main__":
     main()

--- a/workflow/scripts/osemosys_global/OPG_powerplant_data.py
+++ b/workflow/scripts/osemosys_global/OPG_powerplant_data.py
@@ -1447,53 +1447,55 @@ def format_transmission_name(df):
 
 def user_defined_capacity(region, years, output_data_dir, tech_capacity):
     techCapacity = []
-
-    for tech, tech_params in tech_capacity.items():
-        techCapacity.append([tech, tech_params[0], tech_params[1]])
-    tech_capacity_df = pd.DataFrame(techCapacity,
-                                    columns=['TECHNOLOGY', 'VALUE', 'YEAR'])
-    tech_capacity_df['REGION'] = region
-    tech_capacity_df = tech_capacity_df[['REGION', 'TECHNOLOGY', 'YEAR', 'VALUE']]
-
-    tech_set = pd.read_csv(os.path.join(output_data_dir, 'TECHNOLOGY.csv'))
-
-    for each_tech in list(tech_capacity_df['TECHNOLOGY'].unique()):
-        if each_tech not in list(tech_set['VALUE']):
-            tech_capacity_df = tech_capacity_df.loc[~(tech_capacity_df['TECHNOLOGY'].isin([each_tech]))]
     
-    df_min_cap_inv = pd.read_csv(os.path.join(output_data_dir,
-                                              'TotalAnnualMinCapacityInvestment.csv'))
-    df_min_cap_inv = df_min_cap_inv.append(tech_capacity_df)
-    df_min_cap_inv.drop_duplicates(inplace=True)
+    if not tech_capacity is None:
 
-    df_max_cap_inv = pd.read_csv(os.path.join(output_data_dir,
-                                              'TotalAnnualMaxCapacityInvestment.csv'))
+        for tech, tech_params in tech_capacity.items():
+            techCapacity.append([tech, tech_params[0], tech_params[1]])
+        tech_capacity_df = pd.DataFrame(techCapacity,
+                                        columns=['TECHNOLOGY', 'VALUE', 'YEAR'])
+        tech_capacity_df['REGION'] = region
+        tech_capacity_df = tech_capacity_df[['REGION', 'TECHNOLOGY', 'YEAR', 'VALUE']]
 
-    max_cap_techs = []
-    for index, row in tech_capacity_df.iterrows():
-        for each_year in years:
-            if row['YEAR'] == each_year:
-                value = row['VALUE']
-            else:
-                value = 0
-            max_cap_techs.append([row['REGION'],
-                                row['TECHNOLOGY'],
-                                each_year,
-                                value])
-    max_cap_techs_df = pd.DataFrame(max_cap_techs,
-                                    columns=['REGION',
-                                            'TECHNOLOGY',
-                                            'YEAR',
-                                            'VALUE'])
-    df_max_cap_inv = df_max_cap_inv.append(max_cap_techs_df)
-    df_max_cap_inv.drop_duplicates(inplace=True)
+        tech_set = pd.read_csv(os.path.join(output_data_dir, 'TECHNOLOGY.csv'))
 
-    df_max_cap_inv.to_csv(os.path.join(output_data_dir,
-                                    "TotalAnnualMaxCapacityInvestment.csv"),
-                        index=None)
-    df_min_cap_inv.to_csv(os.path.join(output_data_dir,
-                                    "TotalAnnualMinCapacityInvestment.csv"),
-                        index=None)
+        for each_tech in list(tech_capacity_df['TECHNOLOGY'].unique()):
+            if each_tech not in list(tech_set['VALUE']):
+                tech_capacity_df = tech_capacity_df.loc[~(tech_capacity_df['TECHNOLOGY'].isin([each_tech]))]
+        
+        df_min_cap_inv = pd.read_csv(os.path.join(output_data_dir,
+                                                'TotalAnnualMinCapacityInvestment.csv'))
+        df_min_cap_inv = df_min_cap_inv.append(tech_capacity_df)
+        df_min_cap_inv.drop_duplicates(inplace=True)
+
+        df_max_cap_inv = pd.read_csv(os.path.join(output_data_dir,
+                                                'TotalAnnualMaxCapacityInvestment.csv'))
+
+        max_cap_techs = []
+        for index, row in tech_capacity_df.iterrows():
+            for each_year in years:
+                if row['YEAR'] == each_year:
+                    value = row['VALUE']
+                else:
+                    value = 0
+                max_cap_techs.append([row['REGION'],
+                                    row['TECHNOLOGY'],
+                                    each_year,
+                                    value])
+        max_cap_techs_df = pd.DataFrame(max_cap_techs,
+                                        columns=['REGION',
+                                                'TECHNOLOGY',
+                                                'YEAR',
+                                                'VALUE'])
+        df_max_cap_inv = df_max_cap_inv.append(max_cap_techs_df)
+        df_max_cap_inv.drop_duplicates(inplace=True)
+
+        df_max_cap_inv.to_csv(os.path.join(output_data_dir,
+                                        "TotalAnnualMaxCapacityInvestment.csv"),
+                            index=None)
+        df_min_cap_inv.to_csv(os.path.join(output_data_dir,
+                                        "TotalAnnualMinCapacityInvestment.csv"),
+                            index=None)
             
 
 if __name__ == "__main__":

--- a/workflow/scripts/osemosys_global/user_defined_capacity.py
+++ b/workflow/scripts/osemosys_global/user_defined_capacity.py
@@ -1,0 +1,49 @@
+import requests
+import os
+import yaml
+import pandas as pd
+from OPG_configuration import ConfigFile, ConfigPaths
+
+# LOGGING
+import logging
+logging.basicConfig(format='%(levelname)s: %(message)s', level=logging.INFO)
+
+def main():
+    '''Creates capacity limits on renewable technologies.'''
+    
+    # CONFIGURATION PARAMETERS
+    config_paths = ConfigPaths()
+    config = ConfigFile('config')  
+
+    input_dir = config_paths.input_dir
+    output_data_dir = config_paths.output_data_dir
+    region = config.get('region')
+    years = range(config.get('startYear'), config.get('endYear') + 1)
+    tech_capacity = config.get('user_defined_capacity')
+    techCapacity = []
+    for tech, tech_params in tech_capacity.items():
+        techCapacity.append([tech, tech_params[0], tech_params[1]])
+    tech_capacity_df = pd.DataFrame(techCapacity,
+                                    columns=['TECHNOLOGY', 'VALUE', 'YEAR'])
+    tech_capacity_df['REGION'] = region
+    tech_capacity_df = tech_capacity_df[['REGION', 'TECHNOLOGY', 'YEAR', 'VALUE']]
+
+    df_min_cap_inv = pd.read_csv(os.path.join(output_data_dir, 'TotalAnnualMinCapacityInvestment.csv'))
+    df_min_cap_inv = df_min_cap_inv.append(tech_capacity_df)
+    
+    for each_year in list(years):
+        
+        
+    
+    df_max_cap = pd.read_csv(os.path.join(output_data_dir, 'TotalAnnualMaxCapacity.csv'))
+    
+    return print(tech_capacity_df.head(),
+                 '\n',
+                 df_min_cap_inv.head(),
+                 '\n',
+                 df_max_cap.head())
+
+
+if __name__ == '__main__':
+    main()
+    logging.info(f'Max capacity limits sucessfully set')

--- a/workflow/scripts/osemosys_global/user_defined_capacity.py
+++ b/workflow/scripts/osemosys_global/user_defined_capacity.py
@@ -70,4 +70,4 @@ def main():
 
 if __name__ == '__main__':
     main()
-    logging.info(f'Max capacity limits sucessfully set')
+    logging.info(f'User-defined capacities sucessfully set')

--- a/workflow/scripts/osemosys_global/user_defined_capacity.py
+++ b/workflow/scripts/osemosys_global/user_defined_capacity.py
@@ -17,10 +17,12 @@ def main():
 
     input_dir = config_paths.input_dir
     output_data_dir = config_paths.output_data_dir
+    scenario_data_dir = config_paths.scenario_data_dir
     region = config.get('region')
     years = range(config.get('startYear'), config.get('endYear') + 1)
     tech_capacity = config.get('user_defined_capacity')
     techCapacity = []
+    
     for tech, tech_params in tech_capacity.items():
         techCapacity.append([tech, tech_params[0], tech_params[1]])
     tech_capacity_df = pd.DataFrame(techCapacity,
@@ -28,20 +30,42 @@ def main():
     tech_capacity_df['REGION'] = region
     tech_capacity_df = tech_capacity_df[['REGION', 'TECHNOLOGY', 'YEAR', 'VALUE']]
 
-    df_min_cap_inv = pd.read_csv(os.path.join(output_data_dir, 'TotalAnnualMinCapacityInvestment.csv'))
+    tech_set = pd.read_csv(os.path.join(scenario_data_dir, 'TECHNOLOGY.csv'))
+
+    for each_tech in list(tech_capacity_df['TECHNOLOGY'].unique()):
+        if each_tech not in list(tech_set['VALUE']):
+            tech_capacity_df = tech_capacity_df.loc[~(tech_capacity_df['TECHNOLOGY'].isin([each_tech]))]
+    df_min_cap_inv = pd.read_csv(os.path.join(scenario_data_dir, 'TotalAnnualMinCapacityInvestment.csv'))
     df_min_cap_inv = df_min_cap_inv.append(tech_capacity_df)
-    
-    for each_year in list(years):
-        
-        
-    
-    df_max_cap = pd.read_csv(os.path.join(output_data_dir, 'TotalAnnualMaxCapacity.csv'))
-    
-    return print(tech_capacity_df.head(),
-                 '\n',
-                 df_min_cap_inv.head(),
-                 '\n',
-                 df_max_cap.head())
+    df_min_cap_inv.drop_duplicates(inplace=True)
+
+    df_max_cap_inv = pd.read_csv(os.path.join(scenario_data_dir, 'TotalAnnualMaxCapacityInvestment.csv'))
+
+    max_cap_techs = []
+    for index, row in tech_capacity_df.iterrows():
+        for each_year in years:
+            if row['YEAR'] == each_year:
+                value = row['VALUE']
+            else:
+                value = 0
+            max_cap_techs.append([row['REGION'],
+                                  row['TECHNOLOGY'],
+                                  each_year,
+                                  value])
+    max_cap_techs_df = pd.DataFrame(max_cap_techs,
+                                    columns=['REGION',
+                                             'TECHNOLOGY',
+                                             'YEAR',
+                                             'VALUE'])
+    df_max_cap_inv = df_max_cap_inv.append(max_cap_techs_df)
+    df_max_cap_inv.drop_duplicates(inplace=True)
+
+    df_max_cap_inv.to_csv(os.path.join(
+        scenario_data_dir, "TotalAnnualMaxCapacityInvestment.csv"), index=None)
+    df_min_cap_inv.to_csv(os.path.join(
+        scenario_data_dir, "TotalAnnualMinCapacityInvestment.csv"), index=None)
+
+    return print(max_cap_techs_df)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Added a feature to include user-defined capacities

### Description
- User-defined capacities can be specified in the config file (`config.yaml`). Examples of this are powerplant or cross-border interconnector (transmission) capacities
- `OPG_powerplant_data.py` reads in **TotalAnnualMaxCapacityInvestment.csv** and **TotalAnnualMinCapacityInvestment.csv**, and adds the user-defined capacities in them

### Issue Ticket Number
[FEATURE] Add user-defined capacity (https://github.com/OSeMOSYS/osemosys_global/issues/126)


