### PR TITLE
Generation by node metric

### DIFF
--- a/workflow/scripts/osemosys_global/OPG_geographic_filter.py
+++ b/workflow/scripts/osemosys_global/OPG_geographic_filter.py
@@ -58,16 +58,15 @@ for each_csv in Path(output_data_dir).glob('*.csv'):
                             df['FUEL'].str[6:9].isin(geographic_scope) |
                             df['FUEL'].isin(international_fuels)]
 
-            if each_csv == 'FUEL.csv':
+            if str(each_csv).split('/')[-1] == 'FUEL.csv':
                 df = df.loc[df['VALUE'].str[3:6].isin(geographic_scope) | 
                             df['VALUE'].str[6:9].isin(geographic_scope) |
                             df['VALUE'].isin(international_fuels)]
 
-            if each_csv == 'TECHNOLOGY.csv':
+            if str(each_csv).split('/')[-1] == 'TECHNOLOGY.csv':
                 df = df.loc[df['VALUE'].str[3:6].isin(geographic_scope) | 
                             df['VALUE'].str[6:9].isin(geographic_scope) | 
                             df['VALUE'].str[8:11].isin(geographic_scope)]
-
                 df = df.loc[~(
                     df['VALUE'].str.startswith('TRN') &
                     (~(df['VALUE'].str[3:6].isin(geographic_scope)) |

--- a/workflow/scripts/osemosys_global/summarise_results.py
+++ b/workflow/scripts/osemosys_global/summarise_results.py
@@ -192,29 +192,169 @@ def capacity_summary():
                                 )
 
 
-def generation_summary():
+def generation_by_node_summary():
     # CONFIGURATION PARAMETERS
     config_paths = ConfigPaths()
+    config = ConfigFile('config')
     scenario_results_dir = config_paths.scenario_results_dir
     scenario_result_summaries_dir = config_paths.scenario_result_summaries_dir
+    scenario_data_dir = config_paths.scenario_data_dir
+    input_data_dir = config_paths.input_data_dir
 
     # Generation
     df_generation = pd.read_csv(os.path.join(scenario_results_dir,
                                              'ProductionByTechnology.csv'
                                              )
                                 )
+    # GET TECHS TO PLOT
+    generation = list(df_generation.TECHNOLOGY.unique())
+    df_generation['NODE'] = (df_generation['TECHNOLOGY'].str[6:11])
     df_generation = powerplant_filter(df_generation, country=None)
-    df_generation = transform_ts(df_generation)
+    # df_generation = transform_ts(df_generation)
+
+    # GET TIMESLICE DEFINITION
+
+    seasons_raw = config.get('seasons')
+    seasonsData = []
+
+    for s, months in seasons_raw.items():
+        for month in months:
+            seasonsData.append([month, s]) 
+    seasons_df = pd.DataFrame(seasonsData, 
+                              columns=['month', 'season'])
+    seasons_df = seasons_df.sort_values(by=['month']).reset_index(drop=True)
+    dayparts_raw = config.get('dayparts')
+    daypartData = []
+    for dp, hr in dayparts_raw.items():
+        daypartData.append([dp, hr[0], hr[1]])
+    dayparts_df = pd.DataFrame(daypartData,
+                               columns=['daypart', 'start_hour', 'end_hour'])
+    timeshift = config.get('timeshift')
+    dayparts_df['start_hour'] = dayparts_df['start_hour'].map(lambda x: apply_timeshift(x, timeshift))
+    dayparts_df['end_hour'] = dayparts_df['end_hour'].map(lambda x: apply_timeshift(x, timeshift))
+
+    month_names = {1: 'Jan',
+                   2: 'Feb',
+                   3: 'Mar',
+                   4: 'Apr',
+                   5: 'May',
+                   6: 'Jun',
+                   7: 'Jul',
+                   8: 'Aug',
+                   9: 'Sep',
+                   10: 'Oct',
+                   11: 'Nov',
+                   12: 'Dec',
+                   }
+
+    days_per_month = {'Jan': 31,
+                      'Feb': 28,
+                      'Mar': 31,
+                      'Apr': 30,
+                      'May': 31,
+                      'Jun': 30,
+                      'Jul': 31,
+                      'Aug': 31,
+                      'Sep': 30,
+                      'Oct': 31,
+                      'Nov': 30,
+                      'Dec': 31,
+                      }
+
+    seasons_df['month_name'] = seasons_df['month'].map(month_names)
+    seasons_df['days'] = seasons_df['month_name'].map(days_per_month)
+    seasons_df_grouped = seasons_df.groupby(['season'],
+                                            as_index=False)['days'].sum()
+    days_dict = dict(zip(list(seasons_df_grouped['season']),
+                         list(seasons_df_grouped['days'])
+                         )
+                     )
+    seasons_df['days'] = seasons_df['season'].map(days_dict)
+
+    years = config.get_years()
+
+    seasons_dict = dict(zip(list(seasons_df['month']),
+                            list(seasons_df['season'])
+                            )
+                        )
+
+    dayparts_dict = {i: [j, k]
+                     for i, j, k
+                     in zip(list(dayparts_df['daypart']),
+                            list(dayparts_df['start_hour']),
+                            list(dayparts_df['end_hour'])
+                            )
+                     }
+
+    months = list(seasons_dict)
+    hours = list(range(1, 25))
+
+    # APPLY TRANSFORMATION
+    print(generation, months, hours, years)
+    df_ts_template = pd.DataFrame(list(itertools.product(generation,
+                                                         months,
+                                                         hours,
+                                                         years)
+                                       ),
+                                  columns=['TECHNOLOGY',
+                                           'MONTH',
+                                           'HOUR',
+                                           'YEAR']
+                                  )
+
+    df_ts_template = df_ts_template.sort_values(by=['TECHNOLOGY', 'YEAR'])
+    df_ts_template['SEASON'] = df_ts_template['MONTH'].map(seasons_dict)
+    df_ts_template['DAYS'] = df_ts_template['SEASON'].map(days_dict)
+    df_ts_template['YEAR'] = df_ts_template['YEAR'].astype(int)
+    df_ts_template = powerplant_filter(df_ts_template)
+
+    for daypart in dayparts_dict:
+        if dayparts_dict[daypart][0] > dayparts_dict[daypart][1]: # loops over 24hrs
+            df_ts_template.loc[(df_ts_template['HOUR'] >= dayparts_dict[daypart][0]) |
+                          (df_ts_template['HOUR'] < dayparts_dict[daypart][1]),
+                          'DAYPART'] = daypart
+        else:
+            df_ts_template.loc[(df_ts_template['HOUR'] >= dayparts_dict[daypart][0]) &
+                      (df_ts_template['HOUR'] < dayparts_dict[daypart][1]),
+                      'DAYPART'] = daypart
+
+    df_generation['SEASON'] = df_generation['TIMESLICE'].str[0:2]
+    df_generation['DAYPART'] = df_generation['TIMESLICE'].str[2:]
+    df_generation['YEAR'] = df_generation['YEAR'].astype(int)
+    df_generation.drop(['REGION', 'TIMESLICE'],
+                       axis=1,
+                       inplace=True)
+
+    df_generation = pd.merge(df_generation,
+                             df_ts_template,
+                             how='left',
+                             on=['LABEL', 'SEASON', 'DAYPART', 'YEAR']).dropna()
+    df_generation['VALUE'] = (df_generation['VALUE'].mul(1e6))/(df_generation['DAYS'].mul(3600))
+
+    df_generation = df_generation.pivot_table(index=['MONTH', 'HOUR', 'YEAR', 'NODE'],
+                                              columns='LABEL',
+                                              values='VALUE',
+                                              aggfunc='sum').reset_index().fillna(0)
+
+    df_generation['MONTH'] = pd.Categorical(df_generation['MONTH'],
+                                            categories=months,
+                                            ordered=True)
+    df_generation = df_generation.sort_values(by=['MONTH', 'HOUR'])
+    print(df_generation)
+    '''
     df_generation = pd.melt(df_generation,
-                            id_vars=['MONTH', 'HOUR', 'YEAR'],
+                            id_vars=['MONTH', 'HOUR', 'YEAR', 'NODE'],
                             value_vars=[x for x in df_generation.columns
-                                        if x not in ['MONTH', 'HOUR', 'YEAR']],
+                                        if x not in ['MONTH', 'HOUR', 'YEAR', 'NODE']],
                             value_name='VALUE')
-    df_generation['VALUE'] = df_generation['VALUE'].round(2)
-    df_generation = df_generation[['YEAR', 'MONTH', 'HOUR', 'LABEL', 'VALUE']]
+    '''
+    cols_round = [x for x in df_generation.columns
+                  if x not in ['MONTH', 'HOUR', 'YEAR', 'NODE']]
+    df_generation[cols_round] = df_generation[cols_round].round(2)
+    # df_generation = df_generation[['YEAR', 'MONTH', 'HOUR', 'NODE', 'LABEL', 'VALUE']]
 
     return df_generation.to_csv(os.path.join(scenario_result_summaries_dir,
-                                             'Generation.csv'
+                                             'Generation_By_Node.csv'
                                              ),
                                 index=None
                                 )
@@ -370,18 +510,6 @@ def trade_flows():
              'VALUE']]
     df['MODE_OF_OPERATION'] = df['MODE_OF_OPERATION'].astype(int)
     df.loc[df['MODE_OF_OPERATION'] == 2, 'VALUE'] *= -1
-
-    '''
-    df['MODE_OF_OPERATION'].replace({1: 'NODE_1 to NODE_2',
-                                     2: 'NODE_2 to NODE_1'},
-                                    inplace=True)
-    # Assign directions of trade flows
-
-    df = df.pivot_table(index=['MONTH', 'HOUR', 'YEAR', 'TECHNOLOGY'],
-                        columns='MODE_OF_OPERATION',
-                        values='VALUE',
-                        aggfunc='sum').reset_index().fillna(0)
-    '''
 
     df['NODE_1'] = df.TECHNOLOGY.str[3:8]
     df['NODE_2'] = df.TECHNOLOGY.str[8:13]

--- a/workflow/scripts/osemosys_global/visualisation.py
+++ b/workflow/scripts/osemosys_global/visualisation.py
@@ -381,6 +381,7 @@ def plot_generation_hourly():
     df = powerplant_filter(df, country=False)
     plot_colors = pd.Series(df['COLOR'].values, index=df['LABEL']).to_dict()
     df.VALUE = df.VALUE.astype('float64')
+
     df = transform_ts(df)
 
     fig = px.area(df,

--- a/workflow/scripts/osemosys_global/visualisation.py
+++ b/workflow/scripts/osemosys_global/visualisation.py
@@ -195,6 +195,14 @@ def transform_ts(df):
                             )
                      }
 
+    hours_dict = {i: abs(k-j)
+                  for i, j, k
+                  in zip(list(dayparts_df['daypart']),
+                         list(dayparts_df['start_hour']),
+                         list(dayparts_df['end_hour'])
+                         )
+                  }
+
     months = list(seasons_dict)
     hours = list(range(1, 25))
 
@@ -227,24 +235,28 @@ def transform_ts(df):
                       (df_ts_template['HOUR'] < dayparts_dict[daypart][1]),
                       'DAYPART'] = daypart
 
+    df_ts_template = df_ts_template.drop_duplicates()
+
     df['SEASON'] = df['TIMESLICE'].str[0:2]
     df['DAYPART'] = df['TIMESLICE'].str[2:]
     df['YEAR'] = df['YEAR'].astype(int)
-    df.drop(['REGION', 'TIMESLICE'],
+    df.drop(['REGION', 'FUEL', 'TIMESLICE'],
             axis=1,
             inplace=True)
 
+    df = df.groupby(['LABEL', 'SEASON', 'DAYPART', 'YEAR', 'COLOR'],
+                    as_index=False)['VALUE'].sum()
     df = pd.merge(df,
                   df_ts_template,
                   how='left',
-                  on=['LABEL', 'SEASON', 'DAYPART', 'YEAR']).dropna()
-    df['VALUE'] = (df['VALUE'].mul(1e6))/(df['DAYS'].mul(3600))
+                  on=['LABEL', 'SEASON', 'DAYPART', 'YEAR', 'COLOR']).dropna()
+    df['HOUR_COUNT'] = df['DAYPART'].map(hours_dict)
+    df['VALUE'] = (df['VALUE'].mul(1e6))/(df['DAYS']*df['HOUR_COUNT'].mul(3600))
 
     df = df.pivot_table(index=['MONTH', 'HOUR', 'YEAR'],
                         columns='LABEL',
                         values='VALUE',
-                        aggfunc='sum').reset_index().fillna(0)
-
+                        aggfunc='mean').reset_index().fillna(0)
     df['MONTH'] = pd.Categorical(df['MONTH'],
                                  categories=months,
                                  ordered=True)
@@ -381,7 +393,6 @@ def plot_generation_hourly():
     df = powerplant_filter(df, country=False)
     plot_colors = pd.Series(df['COLOR'].values, index=df['LABEL']).to_dict()
     df.VALUE = df.VALUE.astype('float64')
-
     df = transform_ts(df)
 
     fig = px.area(df,
@@ -401,7 +412,7 @@ def plot_generation_hourly():
     fig.update_layout(
         legend_traceorder="reversed",
         title_x=0.5,
-        yaxis_title = 'Petajoules (PJ)')
+        yaxis_title = 'Gigawatt-Hours (GWh)')
     fig['layout']['title']['font'] = dict(size=24)
     fig.for_each_annotation(lambda a: a.update(text=a.text.split("=")[-1]))
     '''


### PR DESCRIPTION
Added a new metric: generation by node in GWh

### Description
- A new metric *Generation_By_Node* is now created as part of the result summaries. This disaggregates the hourly generation by technology type and node.
- A bug in the calculation of hourly results was fixed. Previously, the conversion from timeslices (season-daypart) to a month-hour format did not take the duration of each daypart into account. 

### Issue Ticket Number
- N/A

### Documentation
- N/A