### PR TITLE
trade flow fig update

### DIFF
--- a/workflow/scripts/osemosys_global/visualisation.py
+++ b/workflow/scripts/osemosys_global/visualisation.py
@@ -46,12 +46,10 @@ def main():
             plot_generationannual(country = country)
     
     # Creates transmission maps by year      
-    '''
-    years = [2050]
-    for a in years:
-        plot_transmission_capacity(a)
-        plot_transmission_flow(a)
-    '''
+    years = [config.get('endYear')]
+    for year in years:
+        plot_transmission_capacity(year)
+        plot_transmission_flow(year)
     
 def powerplant_filter(df, country = None):
 


### PR DESCRIPTION
<!--- Provide a short description of the changes in the Title -->

### Description
<!--- Describe your changes in detail -->
Hey @abhishek0208! I see in [this commit](https://github.com/OSeMOSYS/osemosys_global/commit/6e13b9873de8b8ab65ec402f51b37a3c429bfcf4) you commented out the trade flow figures temporarily? Was there a reason why? I just updated the plotting script to add them back in and only plot the last year. I did a quick test and everything still ran fine. 

Just wanted to check that there wasn't a critical reason why they were commented out before I merge the change :) 


### Issue Ticket Number
<!--- Link corresponding issue number -->
na

### Documentation
<!--- Where and how has this change been documented -->
na