### PR TITLE
Added target for generating input data only 

### DIFF
--- a/docs/advanced-functionality.md
+++ b/docs/advanced-functionality.md
@@ -1,19 +1,53 @@
-# Model Modifications
+# Advanced Functionality 
 
 OSeMOSYS Global exposes numerous ways to customize the model. This page describes what 
 these customizations are and how to execute them.
 
+<!-- ## User Defined Data 
+
+A user may want to use the existing structure of OSeMOSYS Global, but sub in 
+their own data. This may be open-data that is different from OSeMOSYS Global's 
+compiled data, or proprietary data. This can eaisly be done. 
+
+In this example, we show how to change the `SpecifiedAnnualDemand` data of a 
+model generated using OSeMOSYS Global
+
+### 1. Generate Template Data 
+
+Instead of running the full workflow, we will only run the workflow up to 
+the generation of the input CSV files through the command: 
+
+```bash
+snakemake generate_input_data -c
+```
+
+### 2. Modify Parameter Data 
+
+At this point, there will be a folder called `results/<scenario>/data/` that 
+holds all template data for the scenario. Find the csv file `SpecifiedAnnualDemand.csv`
+and chnage the values in the `VALUE` column. This can be done for any parameter, 
+not just SpecifiedAnnualDemand. 
+
+:::{warning}
+While any parameter can be updated, do NOT change the set definitions. Sets
+are identified by being named in files with all capitals (ie. REGION.csv). 
+:::
+
+### 3. Run the Remainder of the Workflow 
+
+Restart the workflow, which will build and solve the model, through the command: 
+
+```bash
+snakemake -c
+```
+
 ## Custom Nodes 
 
 A user may wish to introduce custom nodes to improve the spatial resolution of 
-a particular region or country. 
+a particular region or country. In this example, we show how to break the 
+single node country of Indonesia into seven seperate nodes.  
 
-### Example 
- 
-In this example, we show how to break the single node country of Indonesia 
-into seven seperate nodes.  
-
-#### Remove the Existing Node
+### 1. Remove the Existing Node
 
 In the configuration file, remove the existing Indonesia node
 (`INDXX`), through the `nodes_to_remove` parameter
@@ -23,7 +57,7 @@ nodes_to_remove:
   - 'IDNXX'
 ```
 
-#### Add New Nodes
+### 2. Add New Nodes
 
 In the configuration file, add the names of the new nodes you
 wish to add. In this case we will add the nodes `IDNSM`, `IDNJW`, `IDNNU`, 
@@ -45,7 +79,7 @@ nodes_to_add:
   - 'IDNPP'
 ```
 
-#### Add Residual Capacity 
+### 3. Add Residual Capacity 
 
 In the folder `resources/data/custom_nodes`, add any residual capacity to the 
 `residual_capacity.csv`. The data must be formatted as show. The 
@@ -56,7 +90,7 @@ fuel type must be one of the existing fuels in the model (see
 |-----------|-------------|------------|----------|----------|
 | COA       | IDNJW       | 2010       | 2040     | 5000     |
 
-#### Add Specified Annual Demand
+### 4. Add Specified Annual Demand
 
 In the folder `resources/data/custom_nodes`, add the annual demand for each 
 node to the `specified_annual_demand.csv`. The data must be formatted as 
@@ -68,7 +102,7 @@ shown, with the demand given in PJ.
 | IDNSM       | 2021 | 333.22 |
 | IDNSM       | 2022 | 346.53 |
 
-#### Add Specified Demand Profile 
+### 5. Add Specified Demand Profile 
 
 In the folder `resources/data/custom_nodes`, add the demand profile for each 
 node to the `specified_demand_profile.csv`. The data must be formatted as shown.
@@ -87,7 +121,7 @@ will then be aggregated according to the timeslice definition and replicated
 for each year. 
 :::
 
-#### Run the model 
+### 6. Run the model 
 
 Check that the country with custom nodes is listed under the geographic scope
 in the configuration file 
@@ -101,4 +135,4 @@ Then run the workflow as normal from the root directory
 
 ```bash
 snakemake -c
-```
+``` -->

--- a/docs/advanced-functionality.md
+++ b/docs/advanced-functionality.md
@@ -25,7 +25,7 @@ snakemake generate_input_data -c
 
 At this point, there will be a folder called `results/<scenario>/data/` that 
 holds all template data for the scenario. Find the csv file `SpecifiedAnnualDemand.csv`
-and chnage the values in the `VALUE` column. This can be done for any parameter, 
+and change the values in the `VALUE` column. This can be done for any parameter, 
 not just SpecifiedAnnualDemand. 
 
 :::{warning}

--- a/docs/advanced-functionality.md
+++ b/docs/advanced-functionality.md
@@ -3,7 +3,7 @@
 OSeMOSYS Global exposes numerous ways to customize the model. This page describes what 
 these customizations are and how to execute them.
 
-<!-- ## User Defined Data 
+## User Defined Data 
 
 A user may want to use the existing structure of OSeMOSYS Global, but sub in 
 their own data. This may be open-data that is different from OSeMOSYS Global's 
@@ -135,4 +135,4 @@ Then run the workflow as normal from the root directory
 
 ```bash
 snakemake -c
-``` -->
+```

--- a/docs/index.md
+++ b/docs/index.md
@@ -2,9 +2,6 @@
 
 ![OSeMOSYS Global](_static/osemosys-global.png "OSeMOSYS Global")
 
-<!-- ```{include} ../README.md
-``` -->
-
 OSeMOSYS Global is an open-source, open-data model generator for creating
 global energy system models. It can be used to create inter-connected energy
 systems models for both the entire globe and for any geographically diverse
@@ -22,7 +19,7 @@ installation
 getting-started
 contributing
 model-structure
-modifications
+advanced-functionality
 license
 changelog
 citing

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -17,11 +17,10 @@ basemap
 pytest
 world-bank-data
 sklearn
-otoole>=0.11.0
+otoole==0.11.0
 
 # docs
 myst-parser
-sphinx>=3.2.1
-furo
-sphinx-book-theme
-# linkify
+pydata-sphinx-theme==0.8.1
+sphinx-book-theme==0.3.3
+docutils==0.17.1

--- a/setup.cfg
+++ b/setup.cfg
@@ -49,7 +49,6 @@ package_dir =
 # For more information, check out https://semver.org/.
 install_requires =
     importlib-metadata; python_version<"3.8"
-    sphinx>=3.2.1
     furo
     matplotlib
     seaborn
@@ -66,10 +65,10 @@ install_requires =
     pytest
     world-bank-data
     sklearn
-    otoole>=0.11.0
-    sphinx-book-theme
     myst-parser
-    # linkify
+    pydata-sphinx-theme==0.8.1
+    sphinx-book-theme==0.3.3
+    docutils==0.17.1
 
 [options.packages.find]
 where = workflow/scripts

--- a/workflow/snakefile
+++ b/workflow/snakefile
@@ -12,6 +12,10 @@ include: 'rules/preprocess.smk'
 include: 'rules/model.smk'
 include: 'rules/postprocess.smk'
 
+# constants 
+
+OTOOLE_FILES = os.listdir('resources/simplicity/data')
+
 # handlers 
         
 onsuccess:
@@ -40,11 +44,11 @@ rule all:
         expand('results/{scenario}/figures/{result_figure}.html', 
             scenario=config['scenario'], result_figure = result_figures)
 
-rule data_file:
-    message: 
-        'Scenario data file created successfully!'
+rule generate_input_data:
+    message:
+        "Generating input CSV data..."
     input:
-        expand('results/{scenario}/{scenario}.txt', scenario=config['scenario'])
+        csv_files = expand('results/{scenario}/data/{csv}', scenario=config['scenario'], csv=OTOOLE_FILES),
 
 rule make_dag:
     message:


### PR DESCRIPTION
<!--- Provide a short description of the changes in the Title -->

### Description
<!--- Describe your changes in detail -->
Added a new rule in the snakefile to generate only the input CSV data. This is useful for when users are wanting to add in their own data, as previously they would have to manually stop the workflow. An example of this functionality is: 

**1. Generate Template Data** 

Instead of running the full workflow, you will only run the workflow up to the generation of the input CSV files through the command: 

```bash
snakemake generate_input_data -c
```

**2. Modify Parameter Data** 

At this point, there will be a folder called `results/<scenario>/data/` that  holds all template data for the scenario. Find the parameter of interest and change the values in the `VALUE` column. 

**3. Run the Remainder of the Workflow** 

Restart the workflow, which will build and solve the model, through the command: 

```bash
snakemake -c
```

### Issue Ticket Number
<!--- Link corresponding issue number -->
na 

### Documentation
<!--- Where and how has this change been documented -->
Added under the Advanced Functionality section of readthedocs  