### PR TITLE
Restored trade flow figs

### DIFF
--- a/docs/api/osemosys_global.dashboard.components.rst
+++ b/docs/api/osemosys_global.dashboard.components.rst
@@ -1,0 +1,69 @@
+osemosys\_global.dashboard.components package
+=============================================
+
+Submodules
+----------
+
+osemosys\_global.dashboard.components.ids module
+------------------------------------------------
+
+.. automodule:: osemosys_global.dashboard.components.ids
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+osemosys\_global.dashboard.components.input\_data\_tab module
+-------------------------------------------------------------
+
+.. automodule:: osemosys_global.dashboard.components.input_data_tab
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+osemosys\_global.dashboard.components.map\_tab module
+-----------------------------------------------------
+
+.. automodule:: osemosys_global.dashboard.components.map_tab
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+osemosys\_global.dashboard.components.options\_tab module
+---------------------------------------------------------
+
+.. automodule:: osemosys_global.dashboard.components.options_tab
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+osemosys\_global.dashboard.components.result\_data\_tab module
+--------------------------------------------------------------
+
+.. automodule:: osemosys_global.dashboard.components.result_data_tab
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+osemosys\_global.dashboard.components.shared module
+---------------------------------------------------
+
+.. automodule:: osemosys_global.dashboard.components.shared
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+osemosys\_global.dashboard.components.transmission\_tab module
+--------------------------------------------------------------
+
+.. automodule:: osemosys_global.dashboard.components.transmission_tab
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+Module contents
+---------------
+
+.. automodule:: osemosys_global.dashboard.components
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/api/osemosys_global.dashboard.rst
+++ b/docs/api/osemosys_global.dashboard.rst
@@ -1,0 +1,45 @@
+osemosys\_global.dashboard package
+==================================
+
+Subpackages
+-----------
+
+.. toctree::
+   :maxdepth: 4
+
+   osemosys_global.dashboard.components
+
+Submodules
+----------
+
+osemosys\_global.dashboard.app module
+-------------------------------------
+
+.. automodule:: osemosys_global.dashboard.app
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+osemosys\_global.dashboard.constants module
+-------------------------------------------
+
+.. automodule:: osemosys_global.dashboard.constants
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+osemosys\_global.dashboard.utils module
+---------------------------------------
+
+.. automodule:: osemosys_global.dashboard.utils
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+Module contents
+---------------
+
+.. automodule:: osemosys_global.dashboard
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/api/osemosys_global.rst
+++ b/docs/api/osemosys_global.rst
@@ -1,77 +1,70 @@
 osemosys\_global package
 ========================
 
+Subpackages
+-----------
+
+.. toctree::
+   :maxdepth: 4
+
+   osemosys_global.dashboard
+   osemosys_global.visualisation
+
 Submodules
 ----------
 
-osemosys\_global.OPG\_TS\_data module
+osemosys\_global.TS\_data module
+--------------------------------
+
+.. automodule:: osemosys_global.TS_data
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+osemosys\_global.configuration module
 -------------------------------------
 
-.. automodule:: osemosys_global.OPG_TS_data
+.. automodule:: osemosys_global.configuration
    :members:
    :undoc-members:
    :show-inheritance:
 
-osemosys\_global.OPG\_configuration module
+osemosys\_global.demand\_projection module
 ------------------------------------------
 
-.. automodule:: osemosys_global.OPG_configuration
+.. automodule:: osemosys_global.demand_projection
    :members:
    :undoc-members:
    :show-inheritance:
 
-osemosys\_global.OPG\_demand\_projection module
------------------------------------------------
+osemosys\_global.emissions module
+---------------------------------
 
-.. automodule:: osemosys_global.OPG_demand_projection
+.. automodule:: osemosys_global.emissions
    :members:
    :undoc-members:
    :show-inheritance:
 
-osemosys\_global.OPG\_emissions module
---------------------------------------
+osemosys\_global.file\_check module
+-----------------------------------
 
-.. automodule:: osemosys_global.OPG_emissions
+.. automodule:: osemosys_global.file_check
    :members:
    :undoc-members:
    :show-inheritance:
 
-osemosys\_global.OPG\_file\_check module
-----------------------------------------
-
-.. automodule:: osemosys_global.OPG_file_check
-   :members:
-   :undoc-members:
-   :show-inheritance:
-
-osemosys\_global.OPG\_geographic\_filter module
------------------------------------------------
-
-.. automodule:: osemosys_global.OPG_geographic_filter
-   :members:
-   :undoc-members:
-   :show-inheritance:
-
-osemosys\_global.OPG\_max\_capacity module
+osemosys\_global.geographic\_filter module
 ------------------------------------------
 
-.. automodule:: osemosys_global.OPG_max_capacity
+.. automodule:: osemosys_global.geographic_filter
    :members:
    :undoc-members:
    :show-inheritance:
 
-osemosys\_global.OPG\_powerplant\_data module
----------------------------------------------
+osemosys\_global.max\_capacity module
+-------------------------------------
 
-.. automodule:: osemosys_global.OPG_powerplant_data
-   :members:
-   :undoc-members:
-   :show-inheritance:
-
-osemosys\_global.OPG\_variablecosts module
-------------------------------------------
-
-.. automodule:: osemosys_global.OPG_variablecosts
+.. automodule:: osemosys_global.max_capacity
    :members:
    :undoc-members:
    :show-inheritance:
@@ -80,6 +73,14 @@ osemosys\_global.plot\_input\_data module
 -----------------------------------------
 
 .. automodule:: osemosys_global.plot_input_data
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+osemosys\_global.powerplant\_data module
+----------------------------------------
+
+.. automodule:: osemosys_global.powerplant_data
    :members:
    :undoc-members:
    :show-inheritance:
@@ -100,10 +101,26 @@ osemosys\_global.user\_defined\_capacity module
    :undoc-members:
    :show-inheritance:
 
-osemosys\_global.visualisation module
+osemosys\_global.utils module
+-----------------------------
+
+.. automodule:: osemosys_global.utils
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+osemosys\_global.variablecosts module
 -------------------------------------
 
-.. automodule:: osemosys_global.visualisation
+.. automodule:: osemosys_global.variablecosts
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+osemosys\_global.visualise module
+---------------------------------
+
+.. automodule:: osemosys_global.visualise
    :members:
    :undoc-members:
    :show-inheritance:

--- a/docs/api/osemosys_global.visualisation.rst
+++ b/docs/api/osemosys_global.visualisation.rst
@@ -1,0 +1,37 @@
+osemosys\_global.visualisation package
+======================================
+
+Submodules
+----------
+
+osemosys\_global.visualisation.constants module
+-----------------------------------------------
+
+.. automodule:: osemosys_global.visualisation.constants
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+osemosys\_global.visualisation.data module
+------------------------------------------
+
+.. automodule:: osemosys_global.visualisation.data
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+osemosys\_global.visualisation.utils module
+-------------------------------------------
+
+.. automodule:: osemosys_global.visualisation.utils
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+Module contents
+---------------
+
+.. automodule:: osemosys_global.visualisation
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/workflow/scripts/osemosys_global/visualise.py
+++ b/workflow/scripts/osemosys_global/visualise.py
@@ -48,12 +48,10 @@ def main():
             plot_generation_annual(result_data, scenario_figs_dir, country=country)
     
     # Creates transmission maps by year      
-    '''
-    years = [2050]
-    for a in years:
-        plot_transmission_capacity(a)
-        plot_transmission_flow(a)
-    '''
+    years = [config.get('endYear')]
+    for year in years:
+        plot_transmission_capacity(year)
+        plot_transmission_flow(year)
 
 def plot_total_capacity(data: Dict[str,pd.DataFrame], save_dir: str, country:str = None):
     """Plots total capacity chart 


### PR DESCRIPTION
<!--- Provide a short description of the changes in the Title -->

### Description
<!--- Describe your changes in detail -->
In [this commit](https://github.com/OSeMOSYS/osemosys_global/commit/6e13b9873de8b8ab65ec402f51b37a3c429bfcf4), the creation of the trade flow figures was commented out. I think it was due to troubleshooting an error when there was zero transmission capacity in the system (ie. a single node model). This PR restores the creation of the trade flow figures. 

### Issue Ticket Number
<!--- Link corresponding issue number -->
na


### Documentation
<!--- Where and how has this change been documented -->
na
