### PR TITLE
bug fix for issue-156

### DIFF
--- a/workflow/scripts/osemosys_global/OPG_powerplant_data.py
+++ b/workflow/scripts/osemosys_global/OPG_powerplant_data.py
@@ -1532,6 +1532,12 @@ def user_defined_capacity(region, years, output_data_dir, tech_capacity):
         df_min_cap_inv = apply_dtypes(df_min_cap_inv, "TotalAnnualMinCapacityInvestment")
         df_max_cap_inv = apply_dtypes(df_max_cap_inv, "TotalAnnualMaxCapacityInvestment")
         
+        # case where no invest technologies and user_defined_technologies are defined
+        df_min_cap_inv = df_min_cap_inv.drop_duplicates(
+            ["REGION", "TECHNOLOGY", "YEAR"], keep="last")
+        df_max_cap_inv = df_max_cap_inv.drop_duplicates(
+            ["REGION", "TECHNOLOGY", "YEAR"], keep="last")
+        
         df_max_cap_inv.to_csv(os.path.join(output_data_dir,
                                         "TotalAnnualMaxCapacityInvestment.csv"),
                             index=None)


### PR DESCRIPTION
<!--- Provide a short description of the changes in the Title -->

### Description
<!--- Describe your changes in detail -->
Fixes bug described in issue #156, where if a user defined capacity and no invest technology use the same technology, the model breaks because of a double definition. In the solution, the user defined capacity value will override the no invest technology value. 

### Issue Ticket Number
<!--- Link corresponding issue number -->
Closes #156 

### Documentation
<!--- Where and how has this change been documented -->
na