### PR TITLE
Hotfix for plotting transmission with custom nodes 

### DIFF
--- a/workflow/scripts/osemosys_global/visualise.py
+++ b/workflow/scripts/osemosys_global/visualise.py
@@ -236,6 +236,9 @@ def plot_transmission_capacity(
     trn = trn.groupby(['TECHNOLOGY', 'YEAR', 'FROM', 'TO', 'LONGITUDE_FROM', 'LATITUDE_FROM', 'LONGITUDE_TO', 'LATITUDE_TO'],
                     as_index=False)['VALUE'].sum()
     
+    if trn.empty:
+        return
+    
     # assign line widths based on result data 
     scaler = MinMaxScaler()
     maxlinewidth = 3
@@ -330,6 +333,9 @@ def plot_transmission_flow(
     prd = prd.merge(df_centerpoints[['LATITUDE', 'LONGITUDE']], left_on = 'TO', right_index = True, suffixes = ('_FROM', '_TO'))
     prd = prd.groupby(['TECHNOLOGY', 'YEAR', 'FROM', 'TO', 'LONGITUDE_FROM', 'LATITUDE_FROM', 'LONGITUDE_TO', 'LATITUDE_TO'],
                     as_index=False)['VALUE'].sum()
+    
+    if prd.empty:
+        return
     
     scaler = MinMaxScaler()
     maxlinewidth = 3


### PR DESCRIPTION
<!--- Provide a short description of the changes in the Title -->

### Description
<!--- Describe your changes in detail -->
As identified in issue #181, there is an issue with plotting transmission flows if there is a single country and you are using custom nodes. The issue is that there is no centerpoints defined for the custom nodes. 

This hotfix will skip plotting transmission for custom nodes. The issue will be moved to a new ticket. 

### Issue Ticket Number
<!--- Link corresponding issue number -->
na

### Documentation
<!--- Where and how has this change been documented -->
na