### PR TITLE
Remove Peak Load Ratio from Demand Projections

### DIFF
--- a/workflow/scripts/osemosys_global/demand/constants.py
+++ b/workflow/scripts/osemosys_global/demand/constants.py
@@ -13,9 +13,6 @@ POP_COUNTRIES_SOURCE = "IIASA-WiC POP"  # Options are 'IIASA-WiC POP' and 'NCAR'
 GDP_PPP_COUNTRIES_SOURCE = "OECD Env-Growth"  # Options are 'IIASA GDP' and 'OECD Env-Growth'. 'OECD Env-Growth' has more entries.
 URB_COUNTRIES_SOURCE = "NCAR"  #'NCAR' is the only option.
 
-# Peak to total demand ratio
-PEAK_RATIO_FACTOR = 1
-
-# Projection range 
+# Projection range
 START_YEAR = 2010
 END_YEAR = 2100

--- a/workflow/scripts/osemosys_global/demand/projection.py
+++ b/workflow/scripts/osemosys_global/demand/projection.py
@@ -3,7 +3,7 @@
 import pandas as pd
 import numpy as np
 from regression import get_regression_coefficients
-from constants import START_YEAR, END_YEAR, PEAK_RATIO_FACTOR
+from constants import START_YEAR, END_YEAR
 from spatial import get_spatial_mapping_country, get_spatial_mapping_node
 from data import get_nodal_plexos_demand
 

--- a/workflow/scripts/osemosys_global/demand/projection.py
+++ b/workflow/scripts/osemosys_global/demand/projection.py
@@ -28,10 +28,8 @@ def perform_node_projections(
     df = perform_node_projection_step(
         lr, plexos, plexos_demand, iamc_gdp, iamc_pop, iamc_urb, td_losses
     )
-
     proj = _interpolate_yearly_demand(df)
     proj = _get_node_peak_demand_ratio(plexos_demand, proj)
-    # return _adjust_with_peak_demand(proj, PEAK_RATIO_FACTOR)
     return proj
 
 
@@ -342,23 +340,3 @@ def _get_node_peak_demand_ratio(
         .set_index("PLEXOS_Nodes")
         .drop(columns={"Share_%_Country_Demand"})
     )
-
-
-def _adjust_with_peak_demand(
-    projection: pd.DataFrame, peak_ratio_factor: float
-) -> pd.DataFrame:
-    """Calculates projected hourly peak demand by using the relative 2015 peak demand as proxy.
-
-    The peak to total demand ratio can be adjusted by changing the peak_ratio_factor.
-    """
-
-    df = projection.copy()
-
-    for year in range(START_YEAR, 2101):  # TODO fix this to END_YEAR
-        df[year] = (
-            df[year] * peak_ratio_factor * df["Ratio_Peak/Total_Demand_2015"] * 1000
-        ).round(2)
-
-    df["Unit"] = "MW"
-
-    return df


### PR DESCRIPTION
<!--- Provide a short description of the changes in the Title -->

### Description
<!--- Describe your changes in detail -->
As per [this comment](https://github.com/OSeMOSYS/osemosys_global/pull/197#issuecomment-2365181698), I am removing the peak load ratio option from demand projections. 

### Issue Ticket Number
<!--- Link corresponding issue number -->
na

### Documentation
<!--- Where and how has this change been documented -->
na