### PR TITLE
Validation Script Hotfix

### DIFF
--- a/workflow/scripts/osemosys_global/powerplant/fuel_limits.py
+++ b/workflow/scripts/osemosys_global/powerplant/fuel_limits.py
@@ -83,9 +83,18 @@ def get_user_fuel_limits(
 
 
 def merge_template_user_limits(
-    template: pd.Series, user_limits: pd.Series
+    template: pd.Series,
+    user_limits: pd.Series,
+    years: Optional[list[int] | pd.Series] = None,
 ) -> pd.Series:
-    return user_limits.combine_first(template)
+    s = user_limits.combine_first(template)
+    if isinstance(years, list):
+        return s[s.index.get_level_values("YEAR").isin(years)]
+    elif isinstance(years, pd.Series):
+        y = years.to_list()
+        return s[s.index.get_level_values("YEAR").isin(y)]
+    else:
+        return s
 
 
 if __name__ == "__main__":
@@ -97,10 +106,10 @@ if __name__ == "__main__":
         years_csv = snakemake.input.year_csv
         activity_upper_limit_csv = snakemake.output.activity_upper_limit_csv
     else:
-        technology_csv = "results/India/data/TECHNOLOGY.csv"
+        technology_csv = "results/ASEAN/data/TECHNOLOGY.csv"
         fuel_limit_csv = "resources/data/fuel_limits.csv"
-        region_csv = "results/India/data/REGION.csv"
-        years_csv = "results/India/data/YEAR.csv"
+        region_csv = "results/ASEAN/data/REGION.csv"
+        years_csv = "results/ASEAN/data/YEAR.csv"
         activity_upper_limit_csv = ""
 
     regions = import_set(region_csv)
@@ -111,6 +120,6 @@ if __name__ == "__main__":
     template = get_template_fuel_limit(regions, techs, years)
     user_limits = get_user_fuel_limits(regions, fuel_limits)
 
-    activity_upper_limit = merge_template_user_limits(template, user_limits)
+    activity_upper_limit = merge_template_user_limits(template, user_limits, years)
 
     activity_upper_limit.to_csv(activity_upper_limit_csv, index=True)

--- a/workflow/scripts/osemosys_global/storage/investment_constraints.py
+++ b/workflow/scripts/osemosys_global/storage/investment_constraints.py
@@ -53,4 +53,7 @@ def cap_investment_constraints_sto(storage_set, df_max_cap_invest_base,
    
     df_max_cap_invest_sto = apply_dtypes(df_max_cap_invest_sto, "TotalAnnualMaxCapacityInvestment")
 
+    # filter for storages defined in config
+    df_max_cap_invest_sto = df_max_cap_invest_sto[df_max_cap_invest_sto.TECHNOLOGY.isin(storage_set.VALUE)]
+
     return df_max_cap_invest_sto

--- a/workflow/scripts/osemosys_global/validation/utils.py
+++ b/workflow/scripts/osemosys_global/validation/utils.py
@@ -16,9 +16,9 @@ def _join_data(
 
     modelled = modelled.rename(columns={"VALUE": "OSeMOSYS"})
     actual = actual.rename(columns={"VALUE": dataset_name})
-    
-    df = modelled.join(actual, how="inner")
-    
+
+    df = modelled.join(actual, how="left").fillna(0)
+
     index_values = [df.index.get_level_values(x).unique() for x in df.index.names]
     idx = pd.MultiIndex.from_product(index_values, names=df.index.names)
     df = df.reindex(idx, fill_value=0)


### PR DESCRIPTION
<!--- Provide a short description of the changes in the Title -->

### Description
<!--- Describe your changes in detail -->
During validation, some datasets (ie. Ember) will have only some data for 2023 (ie. Includes 2023 India emissions, but not Bhutan). This leads to snakemake issues, as it will expect all countries to have data if at least one country has data. 

This fix will just populate values with zero to write out an empty validation plot for missing data. For example, see Bhutan if emissions from Ember for 2023 if the model start year is 2023. Kinda a hacky fix, but gets the job done to keep snakemake happy. 

![image](https://github.com/user-attachments/assets/cb6bf028-dfde-4372-8621-a7d3c00f47f9)

### Issue Ticket Number
<!--- Link corresponding issue number -->
na

### Documentation
<!--- Where and how has this change been documented -->
na