### PR TITLE
filter fix OAR bug

### DIFF
--- a/workflow/scripts/osemosys_global/powerplant/activity.py
+++ b/workflow/scripts/osemosys_global/powerplant/activity.py
@@ -267,6 +267,9 @@ def activity_master_end(df_pwr_oar_final, df_oar_upstream, df_oar_int,
     
     df_iar_final = apply_dtypes(df_iar_final, "InputActivityRatio")
     
+    df_oar_final = df_oar_final.loc[~((df_oar_final['TECHNOLOGY'].str.startswith('PWR')) & 
+                                      (df_oar_final['FUEL'].str.endswith('INT')))]
+    
     return df_oar_final, df_iar_final
 
 def capact(df_oar_final):

--- a/workflow/scripts/osemosys_global/powerplant/main.py
+++ b/workflow/scripts/osemosys_global/powerplant/main.py
@@ -106,7 +106,7 @@ def main(
                                       custom_nodes, start_year, end_year)
     
     # Set OutputActivitiyRatio for powerplants and set df structure for InputActivityRatio.
-    df_pwr_oar_final, df_pwr_iar_base = activity_output_pwr(df_ratios, region_name)  
+    df_pwr_oar_final, df_pwr_iar_base = activity_output_pwr(df_ratios, region_name)
     
     # Set InputActivityRatio for powerplants.
     df_pwr_iar_final = activity_input_pwr(df_pwr_iar_base, RENEWABLES_LIST, df_eff_node, 
@@ -325,7 +325,7 @@ if __name__ == "__main__":
     else:
         file_plexos = 'resources/data/default/PLEXOS_World_2015_Gold_V1.1.xlsx'
         file_res_limit = 'resources/data/default/PLEXOS_World_MESSAGEix_GLOBIOM_Softlink.xlsx'
-        file_build_rates = 'resources/data/default/powerplant_build_rates.csv'        
+        file_build_rates = 'resources/data/custom/powerplant_build_rates.csv'        
         file_default_op_life = 'resources/data/custom/operational_life.csv'
         file_naming_convention_tech = 'resources/data/default/naming_convention_tech.csv'
         file_weo_costs = 'resources/data/default/weo_2020_powerplant_costs.csv'


### PR DESCRIPTION
@trevorb1 I filtered out the incorrect OAR entries (PWR Tech + INT Fuels). As a sense check I compared the OAR file from +- a year ago to the current one (after the bug fix) and there is still a difference. In the old OAR (left) the tech `MINCOAIND` feeds into the fuel `COA` whereas in the new OAR (right) this does not exist. 

Can you confirm whether this is correct/incorrect?

I suggest to merge this pull request late next week after the training sessions.

![image](https://github.com/user-attachments/assets/924d55a6-2289-4f53-87b8-d6998416e874)

